### PR TITLE
Turkish Lira symbol changed, use the new one

### DIFF
--- a/resources/currency/TRY.json
+++ b/resources/currency/TRY.json
@@ -1,5 +1,5 @@
 {
-    "alternativeSigns": [TL],
+    "alternativeSigns": ["TL"],
     "ISO4217Code": "TRY",
     "ISO4217Number": "949",
     "sign": "₺",

--- a/resources/currency/TRY.json
+++ b/resources/currency/TRY.json
@@ -1,8 +1,8 @@
 {
-    "alternativeSigns": [],
+    "alternativeSigns": ["TL"],
     "ISO4217Code": "TRY",
     "ISO4217Number": "949",
-    "sign": "TL",
+    "sign": "₺",
     "subunits": 100,
     "title": "Turkish lira",
     "usage": [

--- a/resources/currency/TRY.json
+++ b/resources/currency/TRY.json
@@ -1,8 +1,8 @@
 {
-    "alternativeSigns": [],
+    "alternativeSigns": [TL],
     "ISO4217Code": "TRY",
     "ISO4217Number": "949",
-    "sign": "TL",
+    "sign": "₺",
     "subunits": 100,
     "title": "Turkish lira",
     "usage": [


### PR DESCRIPTION
I finally got the time to fix this.
